### PR TITLE
add automatic gunzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ __Features:__
 - incredibly fast
 - uses {node,unix} streams
 - incredibly fast
+- automatic header based gunzip through
+  [gunzip-maybe](https://github.com/mafintosh/gunzip-maybe)
 
 ## Installation
 ```sh

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const parallel = require('parallel-multistream')
 const dateRange = require('date-range-array')
 const stream = require('readable-stream')
+const gunzip = require('gunzip-maybe')
 const S3Lister = require('s3-lister')
+const pumpify = require('pumpify')
 const assert = require('assert')
 const split = require('split2')
 const eol = require('os').EOL
@@ -74,7 +76,7 @@ LogFetcher.prototype._forward = function () {
       if (err) return self.emit('error', err)
       if (self.ended) return
 
-      files.push(fileStream)
+      files.push(pumpify(fileStream, gunzip()))
 
       const ended = rs.ended
       if (ended && (files.length === counter)) streamFiles()

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "cliclopts": "^1.1.1",
     "date-range-array": "^1.0.0",
+    "gunzip-maybe": "^1.2.1",
     "knox": "^0.9.2",
     "minimist": "^1.2.0",
     "parallel-multistream": "^1.0.1",
     "pump": "^1.0.1",
+    "pumpify": "^1.3.3",
     "readable-stream": "^2.0.4",
     "s3-lister": "^0.1.0",
     "split2": "^1.0.0",


### PR DESCRIPTION
log fetcher now detects if a file is in `gzip` format based on the byte signature in the header and unzips if it is. Thanks! :sparkles: